### PR TITLE
Enable users to login to iReporter

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-    "presets": ["@babel/preset-env", "@babel/preset-react"]
+    "presets": ["@babel/preset-env", "@babel/preset-react"],
+    "plugins": [
+        "@babel/plugin-transform-runtime",
+        "@babel/plugin-proposal-class-properties", "transform-regenerator"
+      ]
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    environment: echo $CC_TEST_REPORTER_ID
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - run:
+          name: Setup Dependencies
+          command: npm install
+      - run:
+          name: Run ESlint
+          command: npm run lint
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter 
+            chmod +x ./cc-test-reporter
+      - run:
+          name: Run Tests and Coverage
+          command: |
+            ./cc-test-reporter before-build
+            npm test -- -u
+            ./cc-test-reporter after-build --exit-code $?

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
   "env": {
     "node": true,
     "es6": true,
-    "browser": true
+    "browser": true,
+    "jest": true
   },
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 dist
 .vscode
 .DS_Store
+/coverage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # iReporter-frontend-react
+
+[![CircleCI](https://circleci.com/gh/richien/iReporter-frontend-react.svg?style=svg)](https://circleci.com/gh/richien/iReporter-frontend-react)   [![Maintainability](https://api.codeclimate.com/v1/badges/a973ba239a9ee93a4987/maintainability)](https://codeclimate.com/github/richien/iReporter-frontend-react/maintainability)   [![Test Coverage](https://api.codeclimate.com/v1/badges/a973ba239a9ee93a4987/test_coverage)](https://codeclimate.com/github/richien/iReporter-frontend-react/test_coverage)
+
 Frontend implementation of the iReporter API using React-Redux

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,49 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // eslint-disable-next-line max-len
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  collectCoverageFrom: ['src/**/*.{js,jsx,mjs}'],
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: 'coverage',
+
+  // An array of file extensions your modules use
+  moduleFileExtensions: ['js', 'json', 'jsx'],
+
+  // A map from regular expressions to module names that allow to stub out resources
+  // with a single module
+
+  moduleNameMapper: {
+    '^.+\\.(css|less|scss|jpeg|png|jpg|svg|gif)$': 'identity-obj-proxy'
+  },
+
+  // eslint-disable-next-line max-len
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  setupFiles: ['<rootDir>/src/setupTest.js'],
+
+  // The test environment that will be used for testing
+  testEnvironment: 'jest-environment-jsdom',
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)'],
+
+  // eslint-disable-next-line max-len
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  testPathIgnorePatterns: ['\\\\node_modules\\\\'],
+
+  // eslint-disable-next-line max-len
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  testURL: 'http://localhost',
+
+  // eslint-disable-next-line max-len
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  transformIgnorePatterns: ['<rootDir>/node_modules/'],
+
+  // Indicates whether each individual test should be reported during the run
+  verbose: false
+};

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "webpack-dev-server --open --mode development",
     "build": "webpack --mode production",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint --ext .js --ext .jsx ."
+    "test": "jest --coverage",
+    "lint": "eslint --ext .js --ext .jsx .",
+    "coveralls": "jest --config=jest.config.js --coverage -u"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
+    "coveralls": "^3.0.5",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.1",
     "eslint-config-prettier": "^6.0.0",
@@ -35,7 +37,10 @@
     "eslint-plugin-react": "^7.14.3",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
+    "jest": "^24.8.0",
     "prettier": "^1.18.2",
+    "react-test-renderer": "^16.8.6",
+    "redux-mock-store": "^1.5.3",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "webpack": "^4.38.0",
@@ -43,15 +48,30 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-transform-runtime": "^7.5.5",
+    "axios": "^0.19.0",
+    "babel-plugin-transform-regenerator": "^6.26.0",
     "css-loader": "^3.1.0",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.14.0",
+    "moxios": "^0.4.0",
     "node-sass": "^4.12.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-loader-spinner": "^3.0.0-rc2",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
+    "react-toastify": "^5.3.2",
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!src/store/index.js"
+    ]
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import 'react-toastify/dist/ReactToastify.css';
+import { ToastContainer } from 'react-toastify';
 import { Routes } from './routes/Routes';
-import store from './store/index';
+import store from './store';
 
 const App = () => (
   <Provider store={store}>
+    <ToastContainer />
     <Routes />
   </Provider>
 );

--- a/src/__test__/actions/api/apiCallStatus.test.js
+++ b/src/__test__/actions/api/apiCallStatus.test.js
@@ -1,0 +1,30 @@
+import apiCallStatusReducer from '../../../reducers/api/apiCallStatusReducer';
+
+describe('test apiStatus reducer', () => {
+  it('it tests the reducer increments state by 1 at start of call', () => {
+    const action = { type: 'API_CALL_START' };
+    const state = 0;
+
+    const newstate = apiCallStatusReducer(state, action);
+
+    expect(newstate).toEqual(1);
+  });
+
+  it('it tests the reducer decrements state by 1 on a successfull call', () => {
+    const action = { type: 'MOCK_ACTION_SUCCESS' };
+    const state = 1;
+
+    const newstate = apiCallStatusReducer(state, action);
+
+    expect(newstate).toEqual(0);
+  });
+
+  it('it tests the reducer decrements state by 1 on an errored call', () => {
+    const action = { type: 'API_CALL_ERROR' };
+    const state = 1;
+
+    const newstate = apiCallStatusReducer(state, action);
+
+    expect(newstate).toEqual(0);
+  });
+});

--- a/src/__test__/actions/api/apiUtils.test.js
+++ b/src/__test__/actions/api/apiUtils.test.js
@@ -1,0 +1,24 @@
+import * as apiUtils from '../../../actions/apiActions/apiUtils';
+
+describe('test apiUtils', () => {
+  it("should return 'handleResponse' and a data object", () => {
+    const data = {
+      message: 'new message'
+    };
+    const result = apiUtils.handleResponse(data);
+    expect(result).toEqual(data);
+  });
+
+  it('should throw an error object', () => {
+    const expected = {
+      error: {}
+    };
+    let actual = {};
+    try {
+      apiUtils.handleError(expected);
+    } catch (error) {
+      actual = error;
+      expect(expected).toEqual(actual);
+    }
+  });
+});

--- a/src/__test__/actions/login/loginActions.test.js
+++ b/src/__test__/actions/login/loginActions.test.js
@@ -1,0 +1,53 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import moxios from 'moxios';
+
+import * as actions from '../../../actions/login/loginActions';
+import { login, apiCallStatus } from '../../../actions/types';
+
+const middleware = [thunk];
+const mockStore = configureMockStore(middleware);
+
+describe('doLogin thunk', () => {
+  beforeEach(() => {
+    moxios.install();
+  });
+  afterEach(() => {
+    moxios.uninstall();
+  });
+
+  it('should call the failed action creators when login fails', () => {
+    const store = mockStore({});
+    moxios.wait(() => {
+      const mockrequest = moxios.requests.mostRecent();
+      mockrequest.respondWith({
+        status: 401,
+        error: {}
+      });
+    });
+
+    const expectedActions = [
+      { type: apiCallStatus.API_CALL_START },
+      { type: apiCallStatus.API_CALL_ERROR },
+      { type: login.LOGIN_FAILURE }
+    ];
+    const user = {
+      username: 'james',
+      password: ''
+    };
+    return store.dispatch(actions.doLogin(user)).catch(() => {
+      expect({ type: apiCallStatus.API_CALL_START }).toEqual(expectedActions[0]);
+      expect({ type: apiCallStatus.API_CALL_ERROR }).toEqual(expectedActions[1]);
+      expect({ type: login.LOGIN_FAILURE }).toEqual(expectedActions[2]);
+    });
+  });
+});
+
+describe('loginActions', () => {
+  it("it should return 'LOGIN_SUCCESS' when called", () => {
+    const result = actions.loginSuccess();
+    expect(result).toEqual({
+      type: login.LOGIN_SUCCESS
+    });
+  });
+});

--- a/src/__test__/actions/login/loginApi.test.js
+++ b/src/__test__/actions/login/loginApi.test.js
@@ -1,0 +1,53 @@
+import moxios from 'moxios';
+import { login } from '../../../actions/login/loginApi';
+
+describe('loginApi', () => {
+  beforeEach(() => {
+    moxios.install();
+  });
+  afterEach(() => {
+    moxios.uninstall();
+  });
+
+  it('should call the login method with a success response', () => {
+    moxios.wait(() => {
+      const mockRequest = moxios.requests.mostRecent();
+      mockRequest.respondWith({
+        status: 200,
+        data: {
+          data: {
+            data: [{ access_token: 'sadcsdcasdcasdcasc', user: {} }]
+          }
+        }
+      });
+    });
+    const user = {
+      user: {
+        username: 'james',
+        password: 'asdsacd234EE'
+      }
+    };
+    return login(user).then(response => {
+      expect(response.status).toEqual(200);
+    });
+  });
+
+  it('should call the login method with a failure response', () => {
+    moxios.wait(() => {
+      const mockRequest = moxios.requests.mostRecent();
+      mockRequest.respondWith({
+        status: 401,
+        error: 'Request failed with status code 401'
+      });
+    });
+    const user = {
+      user: {
+        username: 'james',
+        password: ''
+      }
+    };
+    return login(user).catch(error => {
+      expect(error).toEqual(new Error('Request failed with status code 401'));
+    });
+  });
+});

--- a/src/__test__/components/containers/loginPage/LoginForm.test.js
+++ b/src/__test__/components/containers/loginPage/LoginForm.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { shallow } from 'enzyme';
+import LoginFormContainer from '../../../../components/containers/loginPage/LoginFormContainer';
+
+function renderLoginForm(args) {
+  const defaultProps = {
+    username: '',
+    password: '',
+    onChangeHandler: jest.fn(),
+    onSubmitHandler: jest.fn()
+  };
+  const props = { ...defaultProps, ...args };
+  return shallow(<LoginFormContainer {...props} />);
+}
+
+describe('LoginFormContainer', () => {
+  it('should match snapshot', () => {
+    const wrapper = renderLoginForm();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/__test__/components/containers/loginPage/__snapshots__/LoginForm.test.js.snap
+++ b/src/__test__/components/containers/loginPage/__snapshots__/LoginForm.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoginFormContainer should match snapshot 1`] = `ShallowWrapper {}`;

--- a/src/__test__/components/containers/loginPage/__snapshots__/loginPage.test.js.snap
+++ b/src/__test__/components/containers/loginPage/__snapshots__/loginPage.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoginPage should match snapshot 1`] = `ShallowWrapper {}`;

--- a/src/__test__/components/containers/loginPage/loginPage.test.js
+++ b/src/__test__/components/containers/loginPage/loginPage.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { LoginPage, mapStateToProps } from '../../../../components/containers/loginPage/LoginPage';
+
+describe('LoginPage', () => {
+  const defaultProps = {
+    loginAction: {
+      loginAction: () =>
+        new Promise(resolve => {
+          resolve('Successfully logged in');
+        })
+    },
+    history: {}
+  };
+
+  const wrapper = shallow(<LoginPage {...defaultProps} />);
+
+  it('should match snapshot', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should map the state in the store to local props', () => {
+    const state = {
+      loading: false
+    };
+    expect(mapStateToProps(state)).toEqual({
+      loading: false
+    });
+  });
+
+  it('should handle onChange event', () => {
+    wrapper.setState({
+      target: {
+        name: 'password',
+        value: '1234Enter'
+      }
+    });
+    const wrapperInstance = wrapper.instance();
+    const event = {
+      target: {
+        name: 'password',
+        value: '1234Enter'
+      }
+    };
+    jest.spyOn(wrapperInstance, 'onChangeHandler');
+    wrapperInstance.onChangeHandler(event);
+
+    expect(wrapperInstance.onChangeHandler).toBeCalled();
+  });
+});

--- a/src/__test__/components/views/commons/Input.test.js
+++ b/src/__test__/components/views/commons/Input.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Input from '../../../../components/views/commons/Input';
+
+function renderInput(args) {
+  const defaultProps = {
+    label: '',
+    text: '',
+    divClassName: jest.fn(),
+    inputClassName: jest.fn(),
+    type: '',
+    id: '',
+    name: '',
+    value: '',
+    onChangeHandler: jest.fn(),
+    required: false
+  };
+  const props = { ...defaultProps, ...args };
+  return shallow(<Input {...props} />);
+}
+
+describe('LoginFormContainer', () => {
+  it('should match snapshot', () => {
+    const wrapper = renderInput();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/__test__/components/views/commons/__snapshots__/Input.test.js.snap
+++ b/src/__test__/components/views/commons/__snapshots__/Input.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoginFormContainer should match snapshot 1`] = `ShallowWrapper {}`;

--- a/src/__test__/reducers/login/loginReducers.test.js
+++ b/src/__test__/reducers/login/loginReducers.test.js
@@ -1,0 +1,34 @@
+import loginReducer from '../../../reducers/login/loginReducer';
+import * as actions from '../../../actions/login/loginActions';
+
+const initialState = {
+  data: {},
+  error: {}
+};
+
+const data = {
+  user: {
+    username: 'james',
+    access_token: 'sadcasdcasdc.asdcasdasdcas.sadcdcsderbfhb'
+  }
+};
+const error = {
+  message: 'An error occured'
+};
+
+describe(' loginReducer', () => {
+  it('it tests the reducer is called', () => {
+    const newstate = loginReducer(initialState, data);
+    expect(newstate).toEqual(initialState);
+  });
+
+  it('should return true when on successful lodgin', () => {
+    const newstate = loginReducer(initialState, actions.loginSuccess(data));
+    expect(newstate.data).toEqual(data);
+  });
+
+  it('should return false when login fails', () => {
+    const newstate = loginReducer(initialState, actions.loginFailure(error));
+    expect(newstate.error).toEqual({ message: 'An error occured' });
+  });
+});

--- a/src/__test__/routes/Routes.test.js
+++ b/src/__test__/routes/Routes.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Routes } from '../../routes/Routes';
+
+describe('Routes', () => {
+  it('should render Routes component', () => {
+    const wrapper = shallow(<Routes />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/__test__/routes/__snapshots__/Routes.test.js.snap
+++ b/src/__test__/routes/__snapshots__/Routes.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Routes should render Routes component 1`] = `ShallowWrapper {}`;

--- a/src/actions/apiActions/apiCallStatusActions.js
+++ b/src/actions/apiActions/apiCallStatusActions.js
@@ -1,0 +1,9 @@
+import { apiCallStatus } from '../types';
+
+export function apiCallStart() {
+  return { type: apiCallStatus.API_CALL_START };
+}
+
+export function apiCallError() {
+  return { type: apiCallStatus.API_CALL_ERROR };
+}

--- a/src/actions/apiActions/apiUtils.js
+++ b/src/actions/apiActions/apiUtils.js
@@ -1,0 +1,7 @@
+export function handleResponse(response) {
+  return response;
+}
+
+export function handleError(error) {
+  throw error;
+}

--- a/src/actions/login/loginActions.js
+++ b/src/actions/login/loginActions.js
@@ -1,0 +1,33 @@
+/* eslint-disable func-names */
+import { login } from '../types';
+import * as loginApi from './loginApi';
+import * as apiCallStatus from '../apiActions/apiCallStatusActions';
+
+export function loginSuccess(data) {
+  return { type: login.LOGIN_SUCCESS, data };
+}
+
+export function loginFailure(error) {
+  return { type: login.LOGIN_FAILURE, error };
+}
+
+export function doLogin(user) {
+  return function(dispatch) {
+    dispatch(apiCallStatus.apiCallStart());
+    return loginApi
+      .login(user)
+      .then(data => {
+        const loggedIn = true;
+        sessionStorage.setItem('access_token', data.data.data[0].access_token);
+        sessionStorage.setItem('user', data.data.data[0].user);
+        sessionStorage.setItem('isLoggedIn', loggedIn);
+        dispatch(loginSuccess(data));
+      })
+      .catch(error => {
+        dispatch(apiCallStatus.apiCallError());
+        dispatch(loginFailure(error));
+        const errorMessage = 'Username or Password is Invalid. Please Try Again';
+        throw errorMessage;
+      });
+  };
+}

--- a/src/actions/login/loginApi.js
+++ b/src/actions/login/loginApi.js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { handleResponse, handleError } from '../apiActions/apiUtils';
+
+const baseURL = `${process.env.API_DOMAIN}/api/v1/auth/login`;
+
+export function login(user) {
+  return axios
+    .post(baseURL, {
+      username: user.username,
+      password: user.password
+    })
+    .then(response => handleResponse(response))
+    .catch(error => handleError(error));
+}
+
+export default login;

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,0 +1,9 @@
+export const apiCallStatus = {
+  API_CALL_START: 'API_CALL_START',
+  API_CALL_ERROR: 'API_CALL_ERROR'
+};
+
+export const login = {
+  LOGIN_SUCCESS: 'LOGIN_SUCCESS',
+  LOGIN_FAILURE: 'LOGIN_FAILURE'
+};

--- a/src/assets/css/loginPage.scss
+++ b/src/assets/css/loginPage.scss
@@ -1,5 +1,17 @@
+a {
+  color: cornflowerblue;
+}
+
+a:hover {
+    color: lavender;
+}
+
+p {
+    color: darkslategray;
+}
+
 div.container div.row.login-wrapper {
-  margin-top: 5em;
+  margin-top: 15em;
   margin-bottom: 5em;
 }
 .info-color {

--- a/src/components/containers/loginPage/LoginFormContainer.jsx
+++ b/src/components/containers/loginPage/LoginFormContainer.jsx
@@ -1,25 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Loader from 'react-loader-spinner';
 import { Link } from 'react-router-dom';
 import Input from '../../views/commons/Input';
 
-const LoginFormContainer = ({ email, password, onChangeHandler }) => (
+const LoginFormContainer = ({ username, password, onChangeHandler, onSubmitHandler, loading }) => (
   <div className="card">
     <h2 className="card-header info-color white-text text-center py-4">
       <strong>iReporter</strong>
     </h2>
 
     <div className="card-body px-lg-5 pt-0">
-      <form id="text-center">
+      <form id="text-center" onSubmit={onSubmitHandler}>
         <Input
-          type="email"
+          type="text"
           id="materialLoginFormEmail"
-          name="email"
+          name="username"
           inputClassName="form-control"
           divClassName="md-form"
           label="materialLoginFormEmail"
-          text="E-mail"
-          value={email}
+          text="Username"
+          value={username}
           onChangeHandler={onChangeHandler}
         />
 
@@ -37,11 +38,13 @@ const LoginFormContainer = ({ email, password, onChangeHandler }) => (
         <button
           className="btn btn-outline-info btn-rounded btn-block my-4 waves-effect z-depth-0"
           type="submit"
+          disabled={loading}
         >
-          Login
+          {loading ? <Loader type="Puff" color="#00bfff" height="20" width="20" /> : 'Login'}
         </button>
         <p>
           Not a member?
+          {''}
           <Link to="/signup"> Register</Link>
         </p>
       </form>
@@ -50,9 +53,15 @@ const LoginFormContainer = ({ email, password, onChangeHandler }) => (
 );
 
 LoginFormContainer.propTypes = {
-  email: PropTypes.string.isRequired,
+  username: PropTypes.string.isRequired,
   password: PropTypes.string.isRequired,
-  onChangeHandler: PropTypes.func.isRequired
+  onChangeHandler: PropTypes.func.isRequired,
+  onSubmitHandler: PropTypes.func.isRequired,
+  loading: PropTypes.bool
+};
+
+LoginFormContainer.defaultProps = {
+  loading: false
 };
 
 export default LoginFormContainer;

--- a/src/components/containers/loginPage/LoginPage.jsx
+++ b/src/components/containers/loginPage/LoginPage.jsx
@@ -1,32 +1,60 @@
 import React, { Component } from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { toast } from 'react-toastify';
+import { doLogin } from '../../../actions/login/loginActions';
 import LoginFormContainer from './LoginFormContainer';
 
 export class LoginPage extends Component {
-  constructor() {
-    super();
-    this.state = {
-      email: '',
+  state = {
+    user: {
+      username: '',
       password: ''
-    };
-    this.onChangeHandler = this.onChangeHandler.bind(this);
-  }
+    }
+  };
 
-  onChangeHandler(event) {
-    this.setState({ [event.target.name]: event.target.value });
-  }
+  onChangeHandler = event => {
+    const { user } = this.state;
+    const newUserState = {
+      ...user,
+      [event.target.name]: event.target.value
+    };
+    this.setState({ user: newUserState });
+  };
+
+  onSubmitHandler = event => {
+    const { user } = this.state;
+    const { loginAction, history } = this.props;
+    event.preventDefault();
+    loginAction(user)
+      .then(() => {
+        toast.dismiss();
+        toast.success(`Successfully logged in as ${user.username}`, {
+          autoClose: 3000
+        });
+        history.push('/incidents');
+      })
+      .catch(error => {
+        toast.dismiss();
+        toast.error(`${error}`, {
+          autoClose: 3000
+        });
+      });
+  };
 
   render() {
-    const { email, password } = this.state;
+    const { username, password } = this.state;
+    const { loading } = this.props;
     return (
       <div className="container">
-        <div className="row row-wrapper">
+        <div className="row login-wrapper">
           <div className="col-md-6 offset-md-3">
             <LoginFormContainer
-              email={email}
+              username={username}
               password={password}
               onChangeHandler={this.onChangeHandler}
+              onSubmitHandler={this.onSubmitHandler}
+              loading={loading}
             />
           </div>
         </div>
@@ -35,6 +63,24 @@ export class LoginPage extends Component {
   }
 }
 
-const mapStateToProps = state => {};
+LoginPage.propTypes = {
+  loginAction: PropTypes.func.isRequired,
+  history: PropTypes.shape(),
+  loading: PropTypes.bool
+};
 
-export default connect(mapStateToProps)(LoginPage);
+LoginPage.defaultProps = {
+  history: {},
+  loading: false
+};
+
+export function mapStateToProps(state) {
+  return {
+    loading: state.apiCallsInProgress > 0
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  { loginAction: doLogin }
+)(LoginPage);

--- a/src/reducers/api/apiCallStatusReducer.js
+++ b/src/reducers/api/apiCallStatusReducer.js
@@ -1,0 +1,22 @@
+import { apiCallStatus } from '../../actions/types';
+
+const initialState = {
+  apiCallsInProgress: 0
+};
+
+function actionTypeEndsInSuccess(type) {
+  return type.substring(type.length - 8) === '_SUCCESS';
+}
+
+export default function apiCallStatusReducer(state = initialState.apiCallsInProgress, action) {
+  if (action.type === apiCallStatus.API_CALL_START) {
+    return state + 1;
+  }
+  if (actionTypeEndsInSuccess(action.type)) {
+    return state - 1;
+  }
+  if (action.type === apiCallStatus.API_CALL_ERROR) {
+    return state - 1;
+  }
+  return state;
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,3 +1,8 @@
 import { combineReducers } from 'redux';
+import apiCallsInProgress from './api/apiCallStatusReducer';
+import loginReducer from './login/loginReducer';
 
-export default combineReducers({});
+export default combineReducers({
+  apiCallsInProgress,
+  loginReducer
+});

--- a/src/reducers/login/loginReducer.js
+++ b/src/reducers/login/loginReducer.js
@@ -1,0 +1,22 @@
+import { login } from '../../actions/types';
+
+const initialState = {
+  data: {}
+};
+
+export default function loginReducer(state = initialState, action) {
+  switch (action.type) {
+    case login.LOGIN_SUCCESS:
+      return {
+        ...state,
+        data: action.data
+      };
+    case login.LOGIN_FAILURE:
+      return {
+        ...state,
+        error: action.error
+      };
+    default:
+      return state;
+  }
+}

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,12 +1,13 @@
+/* eslint-disable import/no-named-as-default */
 import React from 'react';
 import { Route, BrowserRouter, Switch } from 'react-router-dom';
-import { LoginPage } from '../components/containers/loginPage/LoginPage';
+import LoginPage from '../components/containers/loginPage/LoginPage';
 
 export const Routes = () => (
   <BrowserRouter>
     <div>
       <Switch>
-        <Route exact path="/" component={LoginPage} />
+        {/* <Route exact path="/" component={LoginPage} /> */}
         <Route path="/login" component={LoginPage} />
       </Switch>
     </div>

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 
 module.exports = {
@@ -13,7 +14,7 @@ module.exports = {
         use: ['html-loader']
       },
       {
-        test: /\.scss$/,
+        test: /\.(scss|css)$/,
         use: ['style-loader', 'css-loader', 'sass-loader']
       }
     ]
@@ -25,6 +26,10 @@ module.exports = {
     historyApiFallback: true
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env.API_DOMAIN': JSON.stringify('https://irepo-api.herokuapp.com')
+      // 'process.env.API_DOMAIN': JSON.stringify('http://127.0.0.1:5000')
+    }),
     new HtmlWebPackPlugin({
       template: './public/index.html',
       filename: './index.html'


### PR DESCRIPTION
#### What does this PR do?

- add a login page with a form from which users can log in to the
  their accounts

#### How should this be manually tested?

- navigate to the `/login` on the deployed application to view this route

###Screenshots

![image](https://user-images.githubusercontent.com/6644707/62198768-ef1c9f80-b38a-11e9-96e8-6a1fd863f7ce.png)
