### PR TITLE
Fix bug in navigation when a user is loggedIn

### DIFF
--- a/src/__test__/routes/UnAuthenticated.test.js
+++ b/src/__test__/routes/UnAuthenticated.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import UnAuthenticated from '../../routes/UnAuthenticated';
+
+describe('Authenticated route', () => {
+  it('should render a component if the user is not  logged in', () => {
+    const TestDiv = <div />;
+    sessionStorage.clear();
+    const component = UnAuthenticated(TestDiv)({});
+    expect(component.type.type).toEqual('div');
+  });
+
+  it('should redirect to the incidents page if the user is logged in', () => {
+    const TestDiv = 'test';
+    sessionStorage.setItem('isLoggedIn', true);
+    UnAuthenticated(TestDiv)({});
+  });
+});

--- a/src/components/containers/loginPage/LoginPage.jsx
+++ b/src/components/containers/loginPage/LoginPage.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { toast } from 'react-toastify';
 import { doLogin } from '../../../actions/login/loginActions';
 import LoginFormContainer from './LoginFormContainer';
+import UnAuthenticated from '../../../routes/UnAuthenticated';
 
 export class LoginPage extends Component {
   state = {
@@ -83,4 +84,4 @@ export function mapStateToProps(state) {
 export default connect(
   mapStateToProps,
   { loginAction: doLogin }
-)(LoginPage);
+)(UnAuthenticated(LoginPage));

--- a/src/components/containers/signUpPage/SignUpPage.jsx
+++ b/src/components/containers/signUpPage/SignUpPage.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { toast } from 'react-toastify';
 import { doSignUp } from '../../../actions/signUp/signUpActions';
 import SignUpFormContainer from './SignUpFormContainer';
+import UnAuthenticated from '../../../routes/UnAuthenticated';
 
 export class SignUpPage extends Component {
   state = {
@@ -106,4 +107,4 @@ export function mapStateToProps(state) {
 export default connect(
   mapStateToProps,
   { signUpAction: doSignUp }
-)(SignUpPage);
+)(UnAuthenticated(SignUpPage));

--- a/src/components/views/landingPage/Landing.jsx
+++ b/src/components/views/landingPage/Landing.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-one-expression-per-line */
 import React from 'react';
 import { Link } from 'react-router-dom';
+import UnAuthenticated from '../../../routes/UnAuthenticated';
 
 const divStyle = {
   background: 'cornflowerblue'
@@ -37,4 +38,4 @@ export const Landing = () => (
     </div>
   </div>
 );
-export default Landing;
+export default UnAuthenticated(Landing);

--- a/src/routes/UnAuthenticated.js
+++ b/src/routes/UnAuthenticated.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+const UnAuthenticated = Component => props =>
+  !sessionStorage.getItem('isLoggedIn') ? <Component {...props} /> : <Redirect to="/incidents" />;
+
+export default UnAuthenticated;


### PR DESCRIPTION
#### What does this PR do?

- when logged-in, a user should not be able to access the landing,
  login and registration pages

#### Description of Task to be completed?

- Added a function that restricts access to the login, registration and landing pages
  when a user is logged in. The user is redirected back to the redflags page

#### How should this be manually tested?

- Login to the application and try to access the routes `/login`, `/signup`, `/`. 
- You will be redirected back to the redflags page